### PR TITLE
Add recent bookings display to admin dashboard

### DIFF
--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -144,7 +144,7 @@ export const AdminDashboardContent: React.FC<{ overrideProfile?: any; bypassAuth
   const params = new URLSearchParams(location.search);
   const showDebug = params.get('debug') === '1';
 
-  const [debugInfo, setDebugInfo] = useState<{ pending?: any; memberships?: any; stats?: any; errors: string[] }>({ errors: [] });
+  const [debugInfo, setDebugInfo] = useState<{ pending?: any; memberships?: any; recentBookings?: any; stats?: any; errors: string[] }>({ errors: [] });
 
   const fetchAdminData = async () => {
     setIsLoading(true);

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -154,9 +154,10 @@ export const AdminDashboardContent: React.FC<{ overrideProfile?: any; bypassAuth
       const payload = data as any;
       if (payload?.pending) setPendingDoctors(payload.pending);
       if (payload?.memberships) setUserMemberships(payload.memberships);
+      if (payload?.recentBookings) setRecentBookings(payload.recentBookings);
       if (payload?.stats) setStats(payload.stats);
 
-      setDebugInfo(prev => ({ ...prev, pending: payload.pending, memberships: payload.memberships, stats: payload.stats }));
+      setDebugInfo(prev => ({ ...prev, pending: payload.pending, memberships: payload.memberships, recentBookings: payload.recentBookings, stats: payload.stats }));
     } catch (error: any) {
       setDebugInfo(prev => ({ ...prev, errors: [...prev.errors, (error && error.message) || String(error)] }));
       // If running under local admin session, avoid direct DB calls that will fail under RLS

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -117,6 +117,7 @@ export const AdminDashboard: React.FC = () => {
 export const AdminDashboardContent: React.FC<{ overrideProfile?: any; bypassAuth?: boolean }> = ({ overrideProfile, bypassAuth = false }) => {
   const [pendingDoctors, setPendingDoctors] = useState<PendingDoctor[]>([]);
   const [userMemberships, setUserMemberships] = useState<UserMembership[]>([]);
+  const [recentBookings, setRecentBookings] = useState<RecentBooking[]>([]);
   const [stats, setStats] = useState<DashboardStats>({
     totalDoctors: 0,
     pendingApplications: 0,

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -90,6 +90,22 @@ interface UserMembership {
   } | null;
 }
 
+interface RecentBooking {
+  id: string;
+  appointment_date: string;
+  appointment_time: string;
+  status: string;
+  doctors: {
+    id: string;
+    practice_name: string;
+    user_id: string;
+    profiles: {
+      first_name: string | null;
+      last_name: string | null;
+    } | null;
+  } | null;
+}
+
 export const AdminDashboard: React.FC = () => {
   return (
     <AdminGuard>

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -165,6 +165,7 @@ export const AdminDashboardContent: React.FC<{ overrideProfile?: any; bypassAuth
         await Promise.allSettled([
           fetchPendingDoctors(),
           fetchUserMemberships(),
+          fetchRecentBookings(),
           fetchDashboardStats(),
         ]);
       } else {


### PR DESCRIPTION
## Purpose

Based on user feedback, this change addresses the admin's need to view recent doctor bookings and resolve the "failed to fetch memberships" error. The admin specifically requested the ability to see which doctors have bookings and improve the overall payment system integration visibility.

## Code changes

- **Frontend (AdminDashboard.tsx)**: Added `RecentBooking` interface and state management for recent bookings data
- **Backend (admin-data/index.ts)**: 
  - Fixed service role key environment variable fallback (`SUPABASE_SERVICE_ROLE_KEY` || `SUPABASE_SERVICE_ROLE`)
  - Added recent bookings query with doctor profile information
  - Extended API response to include recent bookings data (last 50 bookings)
- **Data flow**: Integrated recent bookings fetch into existing admin data pipeline with proper error handling and debug infoTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/eeb386cccfc5483ea0453422275109cb/zenith-hub)

👀 [Preview Link](https://eeb386cccfc5483ea0453422275109cb-zenith-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>eeb386cccfc5483ea0453422275109cb</projectId>-->
<!--<branchName>zenith-hub</branchName>-->